### PR TITLE
resume timing after validation output - otherwise dies in debug mode?

### DIFF
--- a/compiler/baseline.cpp
+++ b/compiler/baseline.cpp
@@ -245,6 +245,8 @@ static void bench_frostt(benchmark::State &state, std::string tnsPath, FrosttOp 
             auto outpath = validationPath + key + ".tns";
             taco::write(outpath, result.removeExplicitZeros(result.getFormat()));
         }
+        state.ResumeTiming();
+
     }
 }
 

--- a/compiler/baseline.cpp
+++ b/compiler/baseline.cpp
@@ -490,6 +490,7 @@ static void bench_suitesparse(benchmark::State &state, SuiteSparseOp op, int fil
                 auto outpath = validationPath + key + ".tns";
                 taco::write(outpath, result.removeExplicitZeros(result.getFormat()));
             }
+            state.ResumeTiming();
 
         }
     }


### PR DESCRIPTION
I think this fixes the debug mode. Seems the timing gets paused and if the iterator uses the same state again, it tries to pause a paused timing state.