### PR TITLE
 fix CI 

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -14,10 +14,6 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: 3.8.12
-    - name: Add conda to system path
-      run: |
-        # $CONDA is an environment variable pointing to the root of the miniconda directory
-        echo $CONDA/bin >> $GITHUB_PATH
     - name: Install dependencies
       run: |
         pip install --upgrade pip
@@ -42,7 +38,7 @@ jobs:
         done < ${GITHUB_WORKSPACE}/scripts/tensor_names/suitesparse_ci.txt
     - name: Lint with flake8
       run: |
-        conda install flake8
+        pip install flake8
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics --exclude venv
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide


### PR DESCRIPTION
Issue:
1.  After adding conda to the system path, the python version got pointed to that of the one in conda instead of the intended 3.8.12
2. onda's python version got auto updated to 3.12, which removes the `distutils` package. installation of pip packages in the CI flow such as numpy would fail, showing error `ModuleNotFoundError: No module named 'distutils'`

solution:
1. remove the step that conda to the system path 
2. switch to using pip to install the flake8 linting tool