### PR TITLE
Reenable sparse formal check

### DIFF
--- a/sam/onyx/parse_dot.py
+++ b/sam/onyx/parse_dot.py
@@ -261,8 +261,6 @@ class SAMDotGraph():
             metamapper_env = os.environ.copy()
             metamapper_env["PIPELINED"] = "0"
             # no need to peroform branch delay matching because we have rv interface in sparse
-            metamapper_env["PROVE"] = "0"
-            # FIXME: disable for now until verification of floating point computation is fixed
             metamapper_env["MATCH_BRANCH_DELAY"] = "0"
             subprocess.run(["python", "/aha/MetaMapper/scripts/map_app.py", self.collat_dir + "/alu_coreir_spec.json"],
                            env=metamapper_env)


### PR DESCRIPTION
Removed setting of environment variable that skips formal check while mapping alu operation (since the issue of floating point formal checks failing has been fixed by Jack)