### PR TITLE
remove pydata from the requirements list

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,6 @@ pandas==1.5.3
 Pillow==9.4.0
 pluggy==1.0.0
 py-cpuinfo==9.0.0
-pydata==1.0.0
 pydot==1.4.2
 pyparsing==3.0.9
 pytest==7.2.1


### PR DESCRIPTION
Remove the pydata dependency from requirements.txt. Pydata is no longer available on pip and will break the CI.