### PR TITLE
remove pydata (which no longer exists) from dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,6 @@ pandas==1.5.3
 Pillow==9.4.0
 pluggy==1.0.0
 py-cpuinfo==9.0.0
-pydata==1.0.0
 pydot==1.4.2
 pyparsing==3.0.9
 pytest==7.2.1


### PR DESCRIPTION
1. Removing Pydata from requirement.txt. Pydata seems to no longer exist on the pip repository, leading to failing CI runs