### PR TITLE
Unroll ikj fixes

### DIFF
--- a/sam/onyx/hw_nodes/stream_arbiter_node.py
+++ b/sam/onyx/hw_nodes/stream_arbiter_node.py
@@ -41,7 +41,7 @@ class StreamArbiterNode(HWNode):
             f2io_port_name = "f2io_17_0" if include_E64_HW else "f2io_17"
             new_conns = {
                 'stream_arbiter_to_glb': [
-                    ([(stream_arb, "stream_out"), (other_data, "f2io_17")], 17),
+                    ([(stream_arb, "stream_out"), (other_data, f2io_port_name)], 17),
                 ]
             }
             return new_conns

--- a/sam/onyx/parse_dot.py
+++ b/sam/onyx/parse_dot.py
@@ -42,16 +42,14 @@ class SAMDotGraph():
         self.stage2_count = {}
 
         self.annotate_IO_nodes()
-        # exit()
-        # print(self.graph)
 
         # Rewrite each 3-input joiners to 3 2-input joiners
         self.rewrite_tri_to_binary()
-        self.rewrite_VectorReducer()
 
         self.duplicate_graph(unroll)  # duplicate the entire graph
 
         # Passes to lower to CGRA
+        self.rewrite_VectorReducer()
         self.rewrite_lookup(unroll)
         self.rewrite_arrays()
         # If using real fork, we don't rewrite the rsg broadcast in the same way


### PR DESCRIPTION
1. Swapping the calling sequence of unrolling and remapping vector reduce, now vector reduce can be unrolled.
2. Fixing the hardcoded port name in the stream arbiter